### PR TITLE
Publisher token

### DIFF
--- a/bin/prepublish
+++ b/bin/prepublish
@@ -3,22 +3,12 @@
 # prompts user to update versions, creates git tags, and commits changes
 ./node_modules/.bin/lerna publish --skip-npm
 
-# prompt to push commit
-read -r -p "Would you like to push the publish commit? [y/N] " response
-case "$response" in
-    [yY][eE][sS]|[yY])
-        git push
-        ;;
-    *)
-        exit 1
-        ;;
-esac
-
 # prompt to push tags
-read -r -p "Would you like to push tags? [y/N] " response
+read -r -p "Would you like to \"git push --tags\"? [y/N] " response
 case "$response" in
     [yY][eE][sS]|[yY])
         git push --tags
+        echo "IMPORTANT: remember to push lerna's publish commit to git"
         ;;
     *)
         exit 1

--- a/circle.yml
+++ b/circle.yml
@@ -2,8 +2,14 @@ machine:
   node:
     version: 6.10.0
 
+dependencies:
+  pre:
+    - echo "//registry.npmjs.org/:_authToken=$NPMJS_TOKEN" >> ~/.npmrc
+  override:
+    - bin/install
+
 deployment:
   live:
     branch: master
     commands:
-      - ./node_modules/.bin/lerna exec -- ../publisher/bin/publish --npm-token="$NPMJS_TOKEN"
+      - ./node_modules/.bin/lerna exec -- ../publisher/bin/publish

--- a/circle.yml
+++ b/circle.yml
@@ -3,6 +3,10 @@ machine:
     version: 6.10.0
 
 dependencies:
+  cache_directories:
+    - "packages/atatus/node_modules/"
+    - "packages/publisher/node_modules/"
+    - "packages/s3/node_modules/"
   pre:
     - echo "//registry.npmjs.org/:_authToken=$NPMJS_TOKEN" >> ~/.npmrc
   override:

--- a/packages/publisher/bin/publish
+++ b/packages/publisher/bin/publish
@@ -13,18 +13,11 @@ Usage:
     publish -h | --help
 
 Options:
-    --npm-token=STRING   Update ~/.npmrc with npm token for authentication
-    -h --help            Show this screen
+    -h --help  Show this screen
 `
 
 ;(() => {
-    const args = docopt(DOC)
-    const npmToken = args['--npm-token']
-
-    // write to $HOME directory so `npm publish` picks up config
-    if (npmToken && !sh.test('-f', '~/.npmrc')) {
-        sh.ShellString(`//registry.npmjs.org/:_authToken=${npmToken}`).to('~/.npmrc')
-    }
+    docopt(DOC)
 
     const pwd = sh.pwd().toString()
     const packageJsonPath = resolve(pwd, 'package.json')

--- a/packages/publisher/bin/publish
+++ b/packages/publisher/bin/publish
@@ -45,7 +45,7 @@ Options:
 
     // silent output of npm show since it's handled below
     log('fetching remote version')
-    const versionExec = sh.exec(`npm show ${package.name} version`, { silent: true  })
+    const versionExec = sh.exec(`npm show ${package.name} version`, { silent: true })
 
     // report error without failing
     if (versionExec.stderr) skip(`npm show version error:\n${versionExec.stderr}`)
@@ -54,14 +54,17 @@ Options:
     const remoteVersion = clean(versionExec.stdout)
     log(`verifying ${remoteVersion} <= ${package.version}...`)
     if (satisfies(remoteVersion, `<=${package.version}`)) {
-        skip(`remote is already published`)
+        skip(`version already published`)
     }
 
+    // publish
     log('publishing...')
-    const publishExec = sh.exec('npm publish')
+    const publishExec = sh.exec('npm publish', { silent: true })
     if (publishExec.stderr) {
+        log(`publishing error:\n${publishExec.stderr}`)
         return sh.exit(1)
     } else {
-        log('publishing...done')
+        log(`published successfully:\n${publishExec.stdout}`)
+        return sh.exit(0)
     }
 })()

--- a/packages/publisher/bin/publish
+++ b/packages/publisher/bin/publish
@@ -2,7 +2,7 @@
 
 const sh = require('shelljs')
 const { docopt } = require('docopt')
-const { gt } = require('semver')
+const { clean, satisfies } = require('semver')
 const { resolve } = require('path')
 
 const DOC = `
@@ -44,15 +44,17 @@ Options:
     if (package.private) skip('private package')
 
     // silent output of npm show since it's handled below
+    log('fetching remote version')
     const versionExec = sh.exec(`npm show ${package.name} version`, { silent: true  })
 
     // report error without failing
     if (versionExec.stderr) skip(`npm show version error:\n${versionExec.stderr}`)
 
     // check if remote version is newer
-    const remoteVersion = versionExec.stdout.trim()
-    if (gt(remoteVersion, package.version)) {
-        skip(`newer version found (${remoteVersion})`)
+    const remoteVersion = clean(versionExec.stdout)
+    log(`verifying ${remoteVersion} <= ${package.version}...`)
+    if (satisfies(remoteVersion, `<=${package.version}`)) {
+        skip(`remote is already published`)
     }
 
     log('publishing...')

--- a/packages/publisher/package.json
+++ b/packages/publisher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percolate/publisher",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "NPM publish built for Continuous Deployment",
   "repository": "https://github.com/percolate/blend/tree/master/packages/publisher",
   "bin": {


### PR DESCRIPTION
- fixed CCI not installing dependencies needed for deploy and added caching
- bin/prepublish: removed broken `git push` from 
- publisher/bin/publish: removed creation of .npmrc as to not expose token
- publisher/bin/publish: added better logging