### PR TITLE
eslint-plugin-percolate

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,13 +4,16 @@ machine:
 
 dependencies:
   cache_directories:
-    - "packages/atatus/node_modules/"
-    - "packages/publisher/node_modules/"
-    - "packages/s3/node_modules/"
+    - packages/atatus/node_modules/
+    - packages/eslint-plugin-percolate/node_modules/
+    - packages/publisher/node_modules/
+    - packages/s3/node_modules/
   pre:
     - echo "//registry.npmjs.org/:_authToken=$NPMJS_TOKEN" >> ~/.npmrc
   override:
     - bin/install
+    - npm test:
+        pwd: packages/eslint-plugin-percolate
 
 deployment:
   live:

--- a/circle.yml
+++ b/circle.yml
@@ -12,6 +12,9 @@ dependencies:
     - echo "//registry.npmjs.org/:_authToken=$NPMJS_TOKEN" >> ~/.npmrc
   override:
     - bin/install
+
+test:
+  override:
     - npm test:
         pwd: packages/eslint-plugin-percolate
 

--- a/packages/eslint-plugin-percolate/.gitignore
+++ b/packages/eslint-plugin-percolate/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/packages/eslint-plugin-percolate/README.md
+++ b/packages/eslint-plugin-percolate/README.md
@@ -1,0 +1,48 @@
+# eslint-plugin-percolate
+
+Percolate's custom Eslint rules
+
+## Installation
+
+You'll first need to install [ESLint](http://eslint.org) and [eslint-plugin-import](https://www.npmjs.com/package/eslint-plugin-import):
+
+```
+$ npm i eslint eslint-plugin-import --save-dev
+```
+
+Next, install `eslint-plugin-percolate`:
+
+```
+$ npm install eslint-plugin-percolate --save-dev
+```
+
+**Note:** If you installed ESLint globally (using the `-g` flag) then you must also install `eslint-plugin-percolate` globally.
+
+## Usage
+
+Add `percolate` to the plugins section of your `.eslintrc` configuration file. You can omit the `eslint-plugin-` prefix:
+
+```json
+{
+    "plugins": [
+        "percolate"
+    ]
+}
+```
+
+
+Then configure the rules you want to use under the rules section.
+
+```json
+{
+    "rules": {
+        "percolate/cjs-default": "error",
+        "percolate/no-jsx-id-attrs": "error",
+    }
+}
+```
+
+## Supported Rules
+
+* [cjs-default](docs/rules/cjs-default.md): Verifies that commonJS `require(...).default` and `export default ...` are in sync
+* [no-jsx-id-attrs](docs/rules/no-jsx-id-attrs.md): Prevents "id" attribute on DOM elements in JSX

--- a/packages/eslint-plugin-percolate/docs/rules/cjs-default.md
+++ b/packages/eslint-plugin-percolate/docs/rules/cjs-default.md
@@ -1,0 +1,42 @@
+# Verifies that commonJS `require(...).default` and `export default...` are in sync (cjs-default)
+
+For commonJS, reports if commonJS `require(...).default` and the referenced default export are out of sync. Intended for temporary use when migrating to pure ES6 modules.
+
+This rule is built on top of [eslint-plugin-import][eslint-plugin-import] and leverages its settings `import/*` (most notably `import/resolver`).
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```js
+// bar.js
+// export function bar () {...}
+
+// foo.js
+// export default function foo () {...}
+
+var bar = require('./bar').default // no default export found in ./bar
+var foo = require('./foo') // requiring ES module must reference default
+
+```
+
+Examples of **correct** code for this rule:
+
+```js
+// bar.js
+// export function bar () {...}
+
+// foo.js
+// export default function foo () {...}
+
+var bar = require('./bar')
+var foo = require('./foo').default
+
+```
+
+## When Not To Use It
+
+If you are using CommonJS and [properly hanlding default][babel-plugin] and/or modifying the exported namespace of any module at runtime, you will likely see false positives with this rule.
+
+[babel-plugin]: https://www.npmjs.com/package/babel-plugin-add-module-exports
+[eslint-plugin-import]: https://github.com/benmosher/eslint-plugin-import

--- a/packages/eslint-plugin-percolate/docs/rules/no-jsx-id-attrs.md
+++ b/packages/eslint-plugin-percolate/docs/rules/no-jsx-id-attrs.md
@@ -1,0 +1,29 @@
+# Prevents "id" attribute on DOM elements in JSX (no-jsx-id-attrs)
+
+DOM IDs get assigned to window which can potentially create conflicts (ex. `<div id="foo"></div> === window.foo`)
+
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```js
+
+function Foo() { return <div id="foo" /> }
+
+```
+
+Examples of **correct** code for this rule:
+
+```js
+
+function Foo() { return <MyComponent id="foo" /> }
+
+// custom html tags do not error
+function Foo() { return <foo id="foo" /> }
+
+```
+
+## When Not To Use It
+
+If you don't care about overlapping DOM IDs.

--- a/packages/eslint-plugin-percolate/lib/index.js
+++ b/packages/eslint-plugin-percolate/lib/index.js
@@ -1,0 +1,2 @@
+var requireIndex = require('requireindex')
+module.exports.rules = requireIndex(`${__dirname}/rules`)

--- a/packages/eslint-plugin-percolate/lib/rules/cjs-default.js
+++ b/packages/eslint-plugin-percolate/lib/rules/cjs-default.js
@@ -1,0 +1,60 @@
+const Exports = require('eslint-plugin-import/lib/ExportMap').default
+
+module.exports = {
+    meta: {
+        docs: {
+            description: 'Verifies that commonJS `require(...).default` and export default are in sync',
+            category: 'Possible Errors',
+            recommended: true,
+        },
+        fixable: true,
+    },
+
+    create: function (context) {
+        return {
+            CallExpression: function (node) {
+                // verify `require()` with one argument
+                if (node.callee.name !== 'require' || node.arguments.length !== 1) return null
+
+                // verify require path must be a string with a value
+                if (node.arguments[0].type !== 'Literal' || !node.arguments[0].value) return null
+                var srcPath = node.arguments[0].value
+
+                // get import source from path
+                var imports = Exports.get(srcPath, context)
+                if (!imports) return null
+
+                // report parse errors for imported file
+                if (imports.errors.length) {
+                    var message = `Parse errors in imported module '${srcPath}':` +
+                        `${imports.errors
+                            .map(e => `${e.message} (${e.lineNumber}:${e.column})`)
+                            .join(', ')}`
+                    return context.report({
+                        message,
+                        node,
+                    })
+                }
+
+                var exportHasDefault = imports.get('default')
+                var requireHasDefault = node.parent.type === 'MemberExpression'
+                    && node.parent.property.name === 'default'
+
+                if (exportHasDefault && !requireHasDefault) {
+                    context.report({
+                        message: 'requiring ES module must reference default',
+                        node,
+                        fix: function (fixer) {
+                            return fixer.insertTextAfter(node, '.default')
+                        }
+                    })
+                } else if (requireHasDefault && !exportHasDefault) {
+                    context.report({
+                        message: 'No default export found in module.',
+                        node,
+                    })
+                }
+            },
+        }
+    },
+}

--- a/packages/eslint-plugin-percolate/lib/rules/no-jsx-id-attrs.js
+++ b/packages/eslint-plugin-percolate/lib/rules/no-jsx-id-attrs.js
@@ -1,0 +1,25 @@
+const htmlTags = require('html-tags')
+
+module.exports = {
+    meta: {
+        docs: {
+            description: 'Prevents "id" attribute on DOM elements in JSX',
+            category: 'Possible Errors',
+            recommended: true,
+        },
+    },
+
+    create: function (context) {
+        return {
+            JSXAttribute: function (node) {
+                if (node.name.name !== 'id') return
+                if (!htmlTags.includes(node.parent.name.name)) return
+
+                context.report({
+                    node,
+                    message: 'DOM id attribute is not allowed',
+                })
+            },
+        }
+    },
+}

--- a/packages/eslint-plugin-percolate/package.json
+++ b/packages/eslint-plugin-percolate/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "eslint-plugin-percolate",
+  "version": "0.0.1",
+  "description": "Percolate's Eslint rules",
+  "keywords": [
+    "eslint",
+    "eslintplugin",
+    "eslint-plugin"
+  ],
+  "repository": "https://github.com/percolate/blend/tree/master/packages/eslint-plugin-percolate",
+  "license": "SEE LICENSE IN /LICENSE.md",
+  "main": "lib/index.js",
+  "scripts": {
+    "test": "mocha tests/src --recursive"
+  },
+  "dependencies": {
+    "html-tags": "1.1.1",
+    "eslint-plugin-import": "2.2.0",
+    "requireindex": "1.1.0"
+  },
+  "peerDependencies": {
+    "eslint-plugin-import": "2.2.0"
+  },
+  "devDependencies": {
+    "babel-eslint": "7.2.3",
+    "eslint": "3.19.0",
+    "mocha": "3.3.0"
+  }
+}

--- a/packages/eslint-plugin-percolate/package.json
+++ b/packages/eslint-plugin-percolate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-percolate",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Percolate's Eslint rules",
   "keywords": [
     "eslint",

--- a/packages/eslint-plugin-percolate/tests/fixtures/default-class.js
+++ b/packages/eslint-plugin-percolate/tests/fixtures/default-class.js
@@ -1,0 +1,3 @@
+export default class Class {
+
+}

--- a/packages/eslint-plugin-percolate/tests/fixtures/es7.js
+++ b/packages/eslint-plugin-percolate/tests/fixtures/es7.js
@@ -1,0 +1,17 @@
+// see issue #36
+
+// Foo.jsx
+class Foo {
+    // ES7 static members
+    static bar = true;
+}
+
+export default Foo
+
+export class Bar {
+    static baz = false;
+
+    render () {
+        let { a, ...rest } = { a: 1, b: 2, c: 3 }
+    }
+}

--- a/packages/eslint-plugin-percolate/tests/fixtures/named-exports.js
+++ b/packages/eslint-plugin-percolate/tests/fixtures/named-exports.js
@@ -1,0 +1,18 @@
+const a = 1
+const b = 2
+
+export { a, b }
+
+const c = 3
+export { c as d }
+
+export class ExportedClass {
+
+}
+
+
+// destructuring exports
+export const { destructuredProp } = {}
+export const [arrayKeyProp] = []
+export const [{ deepProp }] = []
+export const { arr: [,, deepSparseElement] } = {}

--- a/packages/eslint-plugin-percolate/tests/src/rules/cjs-default.js
+++ b/packages/eslint-plugin-percolate/tests/src/rules/cjs-default.js
@@ -1,0 +1,55 @@
+const rule = require('../../../lib/rules/cjs-default')
+const RuleTester = require('eslint').RuleTester
+const { resolve } = require('path')
+
+const filename = resolve(__dirname, '../../fixtures/foo.js')
+const parserOptions = {
+    ecmaVersion: 6,
+    sourceType: 'module',
+}
+const ruleTester = new RuleTester()
+ruleTester.run('cjs-default', rule, {
+    valid: [
+        {
+            code: 'var CoolClass = require("./default-class").default',
+            filename,
+            parserOptions,
+        },
+        {
+            code: 'const { ExportedClass } = require("./named-exports")',
+            filename,
+            parserOptions,
+        },
+        {
+            code: 'function a() { var CoolClass = require("./default-class").default }',
+            filename,
+            parserOptions,
+        },
+    ],
+    invalid: [
+        {
+            code: 'var Foo = require("./es7.js")',
+            filename,
+            parserOptions,
+            errors: ['Parse errors in imported module \'./es7.js\':Unexpected token = (6:16)'],
+        },
+        {
+            code: 'var CoolClass = require("./default-class")',
+            filename,
+            parserOptions,
+            errors: ['requiring ES module must reference default'],
+        },
+        {
+            code: 'function a() { var CoolClass = require("./default-class") }',
+            filename,
+            parserOptions,
+            errors: ['requiring ES module must reference default'],
+        },
+        {
+            code: 'var baz = require("./named-exports").default',
+            filename,
+            parserOptions,
+            errors: ['No default export found in module.'],
+        },
+    ]
+})

--- a/packages/eslint-plugin-percolate/tests/src/rules/no-jsx-id-attrs.js
+++ b/packages/eslint-plugin-percolate/tests/src/rules/no-jsx-id-attrs.js
@@ -1,0 +1,32 @@
+const rule = require('../../../lib/rules/no-jsx-id-attrs')
+const RuleTester = require('eslint').RuleTester
+
+const parserOptions = {
+    ecmaFeatures: { jsx: true },
+    parser: 'babel-eslint',
+}
+const ruleTester = new RuleTester()
+ruleTester.run('no-jsx-id-attrs', rule, {
+    valid: [
+        {
+            code: 'function Foo() { return <div data-id="foo" /> }',
+            parserOptions,
+        },
+        {
+            code: 'function Foo() { return <MyComponent id="foo" /> }',
+            parserOptions,
+        },
+        // custom html tags are not supported
+        {
+            code: 'function Foo() { return <foo id="foo" /> }',
+            parserOptions,
+        },
+    ],
+    invalid: [
+        {
+            code: 'function Foo() { return <div id="foo" /> }',
+            parserOptions,
+            errors: ['DOM id attribute is not allowed'],
+        },
+    ],
+})


### PR DESCRIPTION
Moved eslint-plugin-rosetta out of rosetta and into a shared public package. The work around to install local files worked well with npm, not so much with yarn.