### PR TITLE
Optional route params

### DIFF
--- a/packages/eslint-plugin-percolate/docs/rules/import-blacklist.md
+++ b/packages/eslint-plugin-percolate/docs/rules/import-blacklist.md
@@ -7,7 +7,7 @@ This rule disallows importing specific modules or specific keys from their expor
 Examples of **incorrect** code for this rule:
 
 ```jsx
-/* eslint react-link: ["error", [{ import: 'jquery' }, { import: 'react-router', allowAllExcept: ['Link', 'Redirect'], reason: 'Use /our/router.jsx instead' }]] */
+/* eslint import-blacklist: ["error", [{ import: 'jquery' }, { import: 'react-router', allowAllExcept: ['Link', 'Redirect'], reason: 'Use /our/router.jsx instead' }]] */
 
 
 import "jquery" // jquery" is blackedlisted
@@ -21,7 +21,7 @@ import { Link } from "react-router"
 Examples of **correct** code for this rule:
 
 ```jsx
-/* eslint react-link: ["error", [{ import: 'react-router', allowAllExcept: ['Link', 'Redirect'], reason: 'Use /our/router.jsx instead' }]] */
+/* eslint import-blacklist: ["error", [{ import: 'react-router', allowAllExcept: ['Link', 'Redirect'], reason: 'Use /our/router.jsx instead' }]] */
 
 import { Router } from "react-router"
 import { Router, Route } from "react-router"

--- a/packages/eslint-plugin-percolate/docs/rules/react-link.md
+++ b/packages/eslint-plugin-percolate/docs/rules/react-link.md
@@ -3,7 +3,7 @@
 This rule enforces the use a React link components instead of `<a href="..." />`. `<a>` tags can still be used as buttons only if `href` is missing or starts with "javascript:" or "#".
 
 It validates that route prop values are passed as string literals (ex. `to="/my/path"`) and optionally match a `routeRegex`.
-Parameters inside routes (aka dynamic routes) must match `/:\w+/` and be handled by your link components (ex. `<Link to="/user/:user_id" params={ user_id: 1 } />` routes to "/user/1").
+Parameters inside routes (aka dynamic routes) are identified by `/^:(.*$)/` (anything that starts with a colon between two `/`) and be handled by your link components (ex. `<Link to="/user/:user_id" params={ user_id: 1 } />` routes to "/user/1"). Route params can optionally match a `paramRegex`
 
 Repeating static routes isn't DRY but there are good reasons for doing it:
 
@@ -64,4 +64,5 @@ This rule supports an object with the following properties:
         - `routePropName`: The route prop name (ex. `"to"`)
         - `paramsPropName`: Prop name for route params defined as key/value pairs (ex. `"params"`)
 - `routeRegex`: When present, this enforces that all routes match a specific pattern
+- `paramRegex`: When present, this enforces that all route params match a specific pattern
 - `skipValidationPropName`: When present, this prop bypasses static route analysis

--- a/packages/eslint-plugin-percolate/lib/rules/react-link.js
+++ b/packages/eslint-plugin-percolate/lib/rules/react-link.js
@@ -1,4 +1,4 @@
-const PARAM_REGEX = /:\w+/g
+const PARAM_IDENTIFIER_REGEX = /^:(.*$)/
 
 module.exports = {
     meta: {
@@ -60,8 +60,10 @@ module.exports = {
                         description: 'The prop name that bypasses route validation',
                     },
                     routeRegex: {
-                        type: 'string',
                         description: 'A regex pattern route props must match',
+                    },
+                    paramRegex: {
+                        description: 'A regex pattern individual route params must match',
                     },
                 },
                 additionalProperties: false,
@@ -123,7 +125,7 @@ function validateCustomModule(context, node, specifierLookup) {
     if (!module) return
 
     const { props = [] } = module
-    const { routeRegex, skipValidationPropName } = getOptions(context)
+    const { paramRegex, routeRegex, skipValidationPropName } = getOptions(context)
 
     const shouldSkipValidation =
         skipValidationPropName &&
@@ -156,23 +158,39 @@ function validateCustomModule(context, node, specifierLookup) {
         if (routeRegex && !routeAttr.value.value.match(new RegExp(routeRegex))) {
             context.report({
                 node,
-                message: `"${routeAttr.value.value}" does not match routeRegex /${routeRegex}/`,
+                message: `"${routeAttr.value.value}" does not match routeRegex ${routeRegex}`,
             })
         }
+
+        // gather route params and validate their structure
+        const routeParams = []
+        routeAttr.value.value.split('/').forEach(part => {
+            const match = part.match(PARAM_IDENTIFIER_REGEX)
+            if (!match) return
+
+            const param = match[1]
+            routeParams.push(param)
+
+            if (paramRegex && !param.match(paramRegex)) {
+                context.report({
+                    node,
+                    message: `"${part}" does not match paramRegex ${paramRegex}`,
+                })
+            }
+        })
 
         // ignore param validation
         if (!paramsPropName) return
 
-        const matches = (routeAttr.value.value.match(PARAM_REGEX) || []).map(name => name.replace(':', ''))
         const paramsAttr = node.openingElement.attributes.find(
             attr => attr.type === 'JSXAttribute' && attr.name.name === paramsPropName
         )
 
         // route has no params and no params prop is specified (ex. <Link to="/static/url" />)
-        if (!matches.length && !paramsAttr) return
+        if (!routeParams.length && !paramsAttr) return
 
         // route has params (ex. <Link to="/user/:user_id" />)
-        if (matches.length && !paramsAttr) {
+        if (routeParams.length && !paramsAttr) {
             return context.report({ node, message: `"${paramsPropName}" prop missing` })
         }
 
@@ -187,14 +205,17 @@ function validateCustomModule(context, node, specifierLookup) {
             })
         }
 
-        const params = paramsAttr.value.expression.properties.map(prop => prop.key.name)
-        matches.forEach(match => {
+        const params = paramsAttr.value.expression.properties.map(prop => {
+            // Identifier keys use "name" while Literal keys use "value"
+            return prop.key.name || prop.key.value
+        })
+        routeParams.forEach(match => {
             if (!params.some(param => param === match)) {
                 context.report({ node, message: `"${paramsPropName}" missing "${match}" definition` })
             }
         })
         params.forEach(param => {
-            if (!matches.some(match => match === param)) {
+            if (!routeParams.some(match => match === param)) {
                 context.report({ node, message: `"${routePropName}" missing "/:${param}" in route` })
             }
         })

--- a/packages/eslint-plugin-percolate/lib/rules/react-link.js
+++ b/packages/eslint-plugin-percolate/lib/rules/react-link.js
@@ -28,7 +28,7 @@ module.exports = {
                                 props: {
                                     type: 'array',
                                     minLength: 1,
-                                    required: ['routePropName', 'paramsPropName'],
+                                    required: ['routePropName'],
                                     items: {
                                         type: 'object',
                                         properties: {
@@ -159,6 +159,9 @@ function validateCustomModule(context, node, specifierLookup) {
                 message: `"${routeAttr.value.value}" does not match routeRegex /${routeRegex}/`,
             })
         }
+
+        // ignore param validation
+        if (!paramsPropName) return
 
         const matches = (routeAttr.value.value.match(PARAM_REGEX) || []).map(name => name.replace(':', ''))
         const paramsAttr = node.openingElement.attributes.find(

--- a/packages/eslint-plugin-percolate/package.json
+++ b/packages/eslint-plugin-percolate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-percolate",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Percolate's Eslint rules",
   "keywords": [
     "eslint",

--- a/packages/eslint-plugin-percolate/tests/src/rules/react-link.js
+++ b/packages/eslint-plugin-percolate/tests/src/rules/react-link.js
@@ -6,6 +6,8 @@ const parserOptions = {
     parser: 'babel-eslint',
     sourceType: 'module',
 }
+const routeRegex = /^\/.*$/
+const paramRegex = /^[a-z_]+$/
 const options = [
     {
         modules: [
@@ -26,7 +28,8 @@ const options = [
             },
         ],
         skipValidationPropName: 'skip',
-        routeRegex: '^/.*$',
+        routeRegex,
+        paramRegex,
     },
 ]
 const ruleTester = new RuleTester()
@@ -76,7 +79,7 @@ ruleTester.run('react-link', rule, {
             parserOptions,
         },
         {
-            code: 'import Route from "/route.jsx"; <Route path="/foo/:fooId" />',
+            code: 'import Route from "/route.jsx"; <Route path="/foo/:foo_id" />',
             options,
             parserOptions,
         },
@@ -130,7 +133,7 @@ ruleTester.run('react-link', rule, {
             code: 'import Link from "/link.jsx"; <Link to="foo" />',
             options,
             parserOptions,
-            errors: ['"foo" does not match routeRegex /^/.*$/'],
+            errors: [`"foo" does not match routeRegex ${routeRegex}`],
         },
         {
             code: 'import Redirect from "/redirect.jsx"; <Redirect to="/:foo" />',
@@ -161,6 +164,16 @@ ruleTester.run('react-link', rule, {
             options,
             parserOptions,
             errors: ['"skip" prop is not needed'],
+        },
+        {
+            code:
+                'import Redirect from "/redirect.jsx"; <Redirect to="/:foo1" from="/:foo-bar" to_params={{ foo1: 1 }} from_params={{ "foo-bar": 1 }}/>',
+            options,
+            parserOptions,
+            errors: [
+                `":foo-bar" does not match paramRegex ${paramRegex}`,
+                `":foo1" does not match paramRegex ${paramRegex}`,
+            ],
         },
 
         // <a href="..." />

--- a/packages/eslint-plugin-percolate/tests/src/rules/react-link.js
+++ b/packages/eslint-plugin-percolate/tests/src/rules/react-link.js
@@ -20,6 +20,10 @@ const options = [
                     { routePropName: 'to', paramsPropName: 'to_params' },
                 ],
             },
+            {
+                import: '/route.jsx',
+                props: [{ routePropName: 'path' }],
+            },
         ],
         skipValidationPropName: 'skip',
         routeRegex: '^/.*$',
@@ -69,6 +73,11 @@ ruleTester.run('react-link', rule, {
                     modules: [{ import: '/external_link.jsx' }],
                 },
             ],
+            parserOptions,
+        },
+        {
+            code: 'import Route from "/route.jsx"; <Route path="/foo/:fooId" />',
+            options,
             parserOptions,
         },
 


### PR DESCRIPTION
- Made react-link's `paramsPropName` optional to validate routes.
- Added `paramRegex` to validate route params separate from routeRegex (the overall route structure)


Ex. `<Route path="/campaign/:campaignId" />` will no longer error.