### PR TITLE
no-async

### DIFF
--- a/packages/eslint-plugin-percolate/docs/rules/no-async.md
+++ b/packages/eslint-plugin-percolate/docs/rules/no-async.md
@@ -1,0 +1,23 @@
+# No async (no-async)
+
+This can be a potential error if your browser doesn't support async/await
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```js
+async function getFoo() {
+    await foo()
+}
+```
+
+Examples of **correct** code for this rule:
+
+```js
+function getFoo() { return foo() }
+```
+
+## When Not To Use It
+
+If you're using a polyfill

--- a/packages/eslint-plugin-percolate/lib/rules/no-async.js
+++ b/packages/eslint-plugin-percolate/lib/rules/no-async.js
@@ -1,0 +1,25 @@
+module.exports = {
+    meta: {
+        docs: {
+            description: 'Prevents the use of async function declaration',
+            category: 'Possible Errors',
+            recommended: true,
+        },
+    },
+
+    create: function(context) {
+        const verify = function(node) {
+            if (!node.async) return
+
+            context.report({
+                node,
+                message: 'no async function declaration',
+            })
+        }
+
+        return {
+            FunctionDeclaration: verify,
+            FunctionExpression: verify,
+        }
+    },
+}

--- a/packages/eslint-plugin-percolate/package.json
+++ b/packages/eslint-plugin-percolate/package.json
@@ -14,16 +14,16 @@
     "test": "mocha tests/src --recursive"
   },
   "dependencies": {
-    "html-tags": "1.1.1",
-    "eslint-plugin-import": "2.2.0",
+    "html-tags": "2.0.0",
+    "eslint-plugin-import": "2.7.0",
     "requireindex": "1.1.0"
   },
   "peerDependencies": {
-    "eslint-plugin-import": "2.2.0"
+    "eslint-plugin-import": "2.7.0"
   },
   "devDependencies": {
-    "babel-eslint": "7.2.3",
-    "eslint": "3.19.0",
-    "mocha": "3.3.0"
+    "babel-eslint": "8.0.0",
+    "eslint": "4.6.1",
+    "mocha": "3.5.3"
   }
 }

--- a/packages/eslint-plugin-percolate/package.json
+++ b/packages/eslint-plugin-percolate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-percolate",
-  "version": "0.0.7",
+  "version": "0.1.0",
   "description": "Percolate's Eslint rules",
   "keywords": [
     "eslint",

--- a/packages/eslint-plugin-percolate/tests/src/rules/cjs-default.js
+++ b/packages/eslint-plugin-percolate/tests/src/rules/cjs-default.js
@@ -4,7 +4,6 @@ const { resolve } = require('path')
 
 const filename = resolve(__dirname, '../../fixtures/foo.js')
 const parserOptions = {
-    ecmaVersion: 6,
     sourceType: 'module',
 }
 const ruleTester = new RuleTester()

--- a/packages/eslint-plugin-percolate/tests/src/rules/no-async.js
+++ b/packages/eslint-plugin-percolate/tests/src/rules/no-async.js
@@ -1,0 +1,25 @@
+const rule = require('../../../lib/rules/no-async')
+const RuleTester = require('eslint').RuleTester
+
+const parser = 'babel-eslint'
+const ruleTester = new RuleTester()
+ruleTester.run('no-async', rule, {
+    valid: [
+        {
+            code: 'function Foo() { return foo() }',
+            parser,
+        },
+    ],
+    invalid: [
+        {
+            code: 'async function Foo() { await foo() }',
+            parser,
+            errors: ['no async function declaration'],
+        },
+        {
+            code: "it('should', async function Foo() { await foo() })",
+            parser,
+            errors: ['no async function declaration'],
+        },
+    ],
+})

--- a/packages/eslint-plugin-percolate/tests/src/rules/no-jsx-id-attrs.js
+++ b/packages/eslint-plugin-percolate/tests/src/rules/no-jsx-id-attrs.js
@@ -3,7 +3,6 @@ const RuleTester = require('eslint').RuleTester
 
 const parserOptions = {
     ecmaFeatures: { jsx: true },
-    parser: 'babel-eslint',
 }
 const ruleTester = new RuleTester()
 ruleTester.run('no-jsx-id-attrs', rule, {

--- a/packages/eslint-plugin-percolate/tests/src/rules/no-react-proptypes.js
+++ b/packages/eslint-plugin-percolate/tests/src/rules/no-react-proptypes.js
@@ -4,7 +4,6 @@ const { resolve } = require('path')
 
 const filename = resolve(__dirname, '../../fixtures/foo.js')
 const parserOptions = {
-    ecmaVersion: 6,
     sourceType: 'module',
 }
 const ruleTester = new RuleTester()


### PR DESCRIPTION
In tests, it's safe to use async because we use Chrome and wouldn't `try/catch` them. This allows us to safeguard the source until we figure out a polyfill and how to properly handle network errors.