### PR TITLE
Added no-root-arrow-fn rule

### DIFF
--- a/packages/eslint-plugin-percolate/docs/rules/no-root-arrow-fn.md
+++ b/packages/eslint-plugin-percolate/docs/rules/no-root-arrow-fn.md
@@ -1,6 +1,6 @@
 # Forbids arrow functions in the root
 
-Using arrow functions in the root binds context to the window which adds no value.
+Using arrow functions in the root binds context to the module namespace which adds no value.
 It also affects editors "jump to definition" and React displayNames of inline functions.
 
 ## Rule Details

--- a/packages/eslint-plugin-percolate/docs/rules/no-root-arrow-fn.md
+++ b/packages/eslint-plugin-percolate/docs/rules/no-root-arrow-fn.md
@@ -1,0 +1,24 @@
+# Forbids arrow functions in the root
+
+Using arrow functions in the root binds context to the window which adds no value.
+It also affects editors "jump to definition" and React displayNames of inline functions.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```js
+const MyComponent = () => {}
+export const MyComponent = () => {}
+exports.MyComponent = () => {}
+module.exports = { MyComponent: () => {}, myComp: function() {} }
+```
+
+Examples of **correct** code for this rule:
+
+```js
+function MyComponent() { return 'hello' }
+export function MyComponent() { return 'hello' }
+module.exports = function MyComponent() { return 'hello' }
+[].forEach(() => {})
+```

--- a/packages/eslint-plugin-percolate/lib/rules/no-root-arrow-fn.js
+++ b/packages/eslint-plugin-percolate/lib/rules/no-root-arrow-fn.js
@@ -1,0 +1,52 @@
+module.exports = {
+    meta: {
+        docs: {
+            description: 'No arrow functions in root',
+            category: 'Best Practices',
+            recommended: true,
+        },
+    },
+
+    create: function(context) {
+        const verify = (parentNode, node) => {
+            if (node.type === 'ArrowFunctionExpression') {
+                context.report({
+                    node: parentNode,
+                    message: 'No arrow functions in root',
+                })
+            }
+        }
+
+        const verifyVariableDeclaration = (parentNode, node) => {
+            if (
+                node.declarations[0] &&
+                node.declarations[0].type === 'VariableDeclarator' &&
+                node.declarations[0].init
+            ) {
+                verify(parentNode, node.declarations[0].init)
+            }
+        }
+
+        return {
+            ExportNamedDeclaration: node => {
+                if (node.parent.type !== 'Program') return
+                if (!node.declaration) return
+                if (node.declaration.type !== 'VariableDeclaration') return
+                verifyVariableDeclaration(node, node.declaration)
+            },
+            ExpressionStatement: node => {
+                if (node.parent.type !== 'Program') return
+                if (node.expression.type !== 'AssignmentExpression') return
+                if (node.expression.right.type === 'ObjectExpression') {
+                    node.expression.right.properties.forEach(node => verify(node, node.value))
+                } else {
+                    verify(node, node.expression.right)
+                }
+            },
+            VariableDeclaration: node => {
+                if (node.parent.type !== 'Program') return
+                verifyVariableDeclaration(node, node)
+            },
+        }
+    },
+}

--- a/packages/eslint-plugin-percolate/package.json
+++ b/packages/eslint-plugin-percolate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-percolate",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "description": "Percolate's Eslint rules",
   "keywords": [
     "eslint",

--- a/packages/eslint-plugin-percolate/tests/src/rules/no-root-arrow-fn.js
+++ b/packages/eslint-plugin-percolate/tests/src/rules/no-root-arrow-fn.js
@@ -1,0 +1,64 @@
+const rule = require('../../../lib/rules/no-root-arrow-fn')
+const RuleTester = require('eslint').RuleTester
+
+const ruleTester = new RuleTester()
+const parserOptions = {
+    ecmaVersion: 6,
+    sourceType: 'module',
+}
+ruleTester.run('no-root-arrow-fn', rule, {
+    valid: [
+        {
+            code: "function MyComponent() { return 'hello' }",
+            parserOptions,
+        },
+        {
+            code: "export function MyComponent() { return 'hello' }",
+            parserOptions,
+        },
+        {
+            code: "module.exports = function MyComponent() { return 'hello' }",
+            parserOptions,
+        },
+        {
+            code: '[].forEach(() => {})',
+            parserOptions,
+        },
+
+        // make sure the following don't cause unhandled exceptions
+        {
+            code: 'let someVar',
+            parserOptions,
+        },
+        {
+            code: "export { FOO as BAR } from 'foo/bar'",
+            parserOptions,
+        },
+        {
+            code: 'export class UserTasks extends React.PureComponent {}',
+            parserOptions,
+        },
+    ],
+    invalid: [
+        {
+            code: 'const MyComponent = () => {}',
+            errors: ['No arrow functions in root'],
+            parserOptions,
+        },
+        {
+            code: 'export const MyComponent = () => {}',
+            errors: ['No arrow functions in root'],
+            parserOptions,
+        },
+        {
+            code: 'exports.MyComponent = () => {}',
+            errors: ['No arrow functions in root'],
+            parserOptions,
+        },
+        {
+            code: 'module.exports = { MyComponent: () => {}, myComp: function() {} }',
+            errors: ['No arrow functions in root'],
+            parserOptions,
+        },
+    ],
+})


### PR DESCRIPTION
# Forbids arrow functions in the root

Using arrow functions in the root binds context to the window which adds no value.
It also affects editors "jump to definition" and React displayNames of inline functions.

## Rule Details

Examples of **incorrect** code for this rule:

```js
const MyComponent = () => {}
export const MyComponent = () => {}
exports.MyComponent = () => {}
module.exports = { MyComponent: () => {}, myComp: function() {} }
```

Examples of **correct** code for this rule:

```js
function MyComponent() { return 'hello' }
export function MyComponent() { return 'hello' }
module.exports = function MyComponent() { return 'hello' }
[].forEach(() => {})
```