### PR TITLE
refactor: use a more traditional TAG_VERSION_PREFIX

### DIFF
--- a/pkgs/press/CHANGELOG.md
+++ b/pkgs/press/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+
+## [1.0.6](https://github.com/percolate/blend/tree/master/pkgs/press/compare/@percolate/press@1.0.5...@percolate/press@1.0.6) (2020-03-24)
+
+**Note:** Version bump only for package @percolate/press
+
+
+
+
 ## [1.0.5](https://github.com/percolate/blend/tree/master/pkgs/press/compare/@percolate/press@1.0.4...@percolate/press@1.0.5) (2019-11-18)
 
 **Note:** Version bump only for package @percolate/press

--- a/pkgs/press/package.json
+++ b/pkgs/press/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percolate/press",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "CI release tooling",
   "bin": {
     "press": "bin/press"

--- a/pkgs/press/src/cli/push.ts
+++ b/pkgs/press/src/cli/push.ts
@@ -173,7 +173,7 @@ async function pushLatest(ecr: AWS.ECR, repoUri: string, opts: IPushOpts) {
         // check if semver is newer than latest
         const latestVersion = getPrefixedValue(TAG_VERSION_PREFIX, latestImageTags)
         if (latestVersion && semverUtils.gt(latestVersion, semver)) {
-            return cleanExit(`Newer version has already been push to ":latest" (${latestVersion})`)
+            return cleanExit(`Newer version has already been pushed to ":latest" (${latestVersion})`)
         }
     } else {
         // check if current commit hash is an ancestor of the latest image commit hash
@@ -181,7 +181,7 @@ async function pushLatest(ecr: AWS.ECR, repoUri: string, opts: IPushOpts) {
         if (latestHash) {
             execSync(`git merge-base --is-ancestor ${latestHash} ${hash}`, {
                 onError: () => {
-                    cleanExit(`Newer hash has already been push to ":latest" (${latestHash})`)
+                    cleanExit(`Newer hash has already been pushed to ":latest" (${latestHash})`)
                 },
             })
         }

--- a/pkgs/press/src/constants.ts
+++ b/pkgs/press/src/constants.ts
@@ -5,4 +5,4 @@ export const REGION = 'us-west-1'
 export const SENTRY_CLI = resolve(__dirname, '../node_modules/.bin/sentry-cli')
 export const TAG_BRANCH_PREFIX = 'branch-'
 export const TAG_COMMIT_PREFIX = 'commit-'
-export const TAG_VERSION_PREFIX = 'version-'
+export const TAG_VERSION_PREFIX = process.env.TAG_VERSION_PREFIX || 'v'


### PR DESCRIPTION
Tags like `something:v1.2.3` follow a more traditional/standard version naming convention than the current `something:version-1.2.3` when pushing using `--semver`.
Ideally, this prefix should be empty.