### PR TITLE
chore(deps): bump aws-sdk from 2.569.0 to 2.867.0

### DIFF
--- a/pkgs/cli-utils/CHANGELOG.md
+++ b/pkgs/cli-utils/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.8](https://github.com/percolate/blend/tree/master/pkgs/core/compare/@percolate/cli-utils@0.1.7...@percolate/cli-utils@0.1.8) (2021-03-22)
+
+**Note:** Version bump only for package @percolate/cli-utils
+
+
+
+
+
 ## [0.1.7](https://github.com/percolate/blend/tree/master/pkgs/core/compare/@percolate/cli-utils@0.1.6...@percolate/cli-utils@0.1.7) (2021-03-20)
 
 **Note:** Version bump only for package @percolate/cli-utils

--- a/pkgs/cli-utils/package.json
+++ b/pkgs/cli-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percolate/cli-utils",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Percolate CLI utils",
   "license": "CPAL-1.0",
   "repository": "https://github.com/percolate/blend/tree/master/pkgs/core",

--- a/pkgs/eslint-plugin/CHANGELOG.md
+++ b/pkgs/eslint-plugin/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.1.10](https://github.com/percolate/blend/tree/master/pkgs/eslint-plugin/compare/@percolate/eslint-plugin@1.1.9...@percolate/eslint-plugin@1.1.10) (2021-03-22)
+
+**Note:** Version bump only for package @percolate/eslint-plugin
+
+
+
+
+
 ## [1.1.9](https://github.com/percolate/blend/tree/master/pkgs/eslint-plugin/compare/@percolate/eslint-plugin@1.1.8...@percolate/eslint-plugin@1.1.9) (2021-03-20)
 
 **Note:** Version bump only for package @percolate/eslint-plugin

--- a/pkgs/eslint-plugin/package.json
+++ b/pkgs/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percolate/eslint-plugin",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "description": "Percolate's ESlint rules and configs",
   "repository": "https://github.com/percolate/blend/tree/master/pkgs/eslint-plugin",
   "license": "CPAL-1.0",

--- a/pkgs/kona/CHANGELOG.md
+++ b/pkgs/kona/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.4.2](https://github.com/percolate/blend/tree/master/pkgs/kona/compare/@percolate/kona@3.4.1...@percolate/kona@3.4.2) (2021-03-22)
+
+**Note:** Version bump only for package @percolate/kona
+
+
+
+
+
 ## [3.4.1](https://github.com/percolate/blend/tree/master/pkgs/kona/compare/@percolate/kona@3.4.0...@percolate/kona@3.4.1) (2021-03-20)
 
 

--- a/pkgs/kona/package.json
+++ b/pkgs/kona/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percolate/kona",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "description": "Percolate CLI",
   "license": "CPAL-1.0",
   "repository": "https://github.com/percolate/blend/tree/master/pkgs/kona",
@@ -29,7 +29,7 @@
     "@commitlint/format": "11.0.0",
     "@commitlint/lint": "11.0.0",
     "@commitlint/load": "11.0.0",
-    "@percolate/cli-utils": "0.1.7",
+    "@percolate/cli-utils": "0.1.8",
     "commitizen": "4.2.1",
     "fast-glob": "3.2.5",
     "find-up": "4.1.0",

--- a/pkgs/press/CHANGELOG.md
+++ b/pkgs/press/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.2.8](https://github.com/percolate/blend/tree/master/pkgs/press/compare/@percolate/press@1.2.7...@percolate/press@1.2.8) (2021-03-22)
+
+**Note:** Version bump only for package @percolate/press
+
+
+
+
+
 ## [1.2.7](https://github.com/percolate/blend/tree/master/pkgs/press/compare/@percolate/press@1.2.6...@percolate/press@1.2.7) (2021-03-20)
 
 **Note:** Version bump only for package @percolate/press

--- a/pkgs/press/package.json
+++ b/pkgs/press/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percolate/press",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "CI release tooling",
   "bin": {
     "press": "bin/press"
@@ -16,7 +16,7 @@
     "watch": "tsc --project . --watch"
   },
   "dependencies": {
-    "@percolate/cli-utils": "0.1.7",
+    "@percolate/cli-utils": "0.1.8",
     "@sentry/cli": "1.49.0",
     "aws-sdk": "2.867.0",
     "semver": "6.3.0",

--- a/pkgs/press/package.json
+++ b/pkgs/press/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@percolate/cli-utils": "0.1.7",
     "@sentry/cli": "1.49.0",
-    "aws-sdk": "2.569.0",
+    "aws-sdk": "2.867.0",
     "semver": "6.3.0",
     "yargs": "14.2.0"
   },

--- a/pkgs/prettier-config/CHANGELOG.md
+++ b/pkgs/prettier-config/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.6](https://github.com/percolate/blend/tree/master/pkgs/prettier-config/compare/@percolate/prettier-config@0.1.5...@percolate/prettier-config@0.1.6) (2021-03-22)
+
+**Note:** Version bump only for package @percolate/prettier-config
+
+
+
+
+
 ## [0.1.5](https://github.com/percolate/blend/tree/master/pkgs/prettier-config/compare/@percolate/prettier-config@0.1.4...@percolate/prettier-config@0.1.5) (2021-03-20)
 
 **Note:** Version bump only for package @percolate/prettier-config

--- a/pkgs/prettier-config/package.json
+++ b/pkgs/prettier-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percolate/prettier-config",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Percolate prettier config",
   "repository": "https://github.com/percolate/blend/tree/master/pkgs/prettier-config",
   "license": "CPAL-1.0",

--- a/pkgs/publisher/CHANGELOG.md
+++ b/pkgs/publisher/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.7](https://github.com/percolate/blend/tree/master/pkgs/publisher/compare/@percolate/publisher@0.1.6...@percolate/publisher@0.1.7) (2021-03-22)
+
+**Note:** Version bump only for package @percolate/publisher
+
+
+
+
+
 ## [0.1.6](https://github.com/percolate/blend/tree/master/pkgs/publisher/compare/@percolate/publisher@0.1.5...@percolate/publisher@0.1.6) (2021-03-20)
 
 **Note:** Version bump only for package @percolate/publisher

--- a/pkgs/publisher/package.json
+++ b/pkgs/publisher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percolate/publisher",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Publish package if version is newer than NPM's",
   "repository": "https://github.com/percolate/blend/tree/master/pkgs/publisher",
   "bin": {
@@ -19,7 +19,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@percolate/cli-utils": "0.1.7",
+    "@percolate/cli-utils": "0.1.8",
     "docopt": "0.6.2",
     "semver": "6.3.0"
   },

--- a/pkgs/s3/CHANGELOG.md
+++ b/pkgs/s3/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.2.7](https://github.com/percolate/blend/tree/master/pkgs/s3/compare/@percolate/s3@1.2.6...@percolate/s3@1.2.7) (2021-03-22)
+
+**Note:** Version bump only for package @percolate/s3
+
+
+
+
+
 ## [1.2.6](https://github.com/percolate/blend/tree/master/pkgs/s3/compare/@percolate/s3@1.2.5...@percolate/s3@1.2.6) (2021-03-20)
 
 **Note:** Version bump only for package @percolate/s3

--- a/pkgs/s3/package.json
+++ b/pkgs/s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percolate/s3",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "CLI for various S3 commands",
   "license": "CPAL-1.0",
   "repository": "https://github.com/percolate/blend/tree/master/pkgs/s3",
@@ -19,7 +19,7 @@
     "watch": "tsc --build tsconfig.json --watch --preserveWatchOutput"
   },
   "dependencies": {
-    "@percolate/cli-utils": "0.1.7",
+    "@percolate/cli-utils": "0.1.8",
     "aws-sdk": "2.867.0",
     "console.table": "0.10.0",
     "docopt": "0.6.2",

--- a/pkgs/s3/package.json
+++ b/pkgs/s3/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@percolate/cli-utils": "0.1.7",
-    "aws-sdk": "2.569.0",
+    "aws-sdk": "2.867.0",
     "console.table": "0.10.0",
     "docopt": "0.6.2",
     "lodash.chunk": "4.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2124,20 +2124,20 @@ atob@^2.1.2:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-aws-sdk@2.569.0:
-  version "2.569.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.569.0.tgz#a350583bd135d7106d2f92fb463df3239051361b"
-  integrity sha512-9i4n/8kR1cq+Ge1n9FzqEBE1kpF8uLEI24wssy0dQD1fks+eNoZ6b3bGMCR1OfYB0KVgIN7ZkUrng1Zu9M4fcA==
+aws-sdk@2.867.0:
+  version "2.867.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.867.0.tgz#3fae9a583bfd89f6098dc9bca6553b5b85e2a2fc"
+  integrity sha512-6iXRTW6dlCU4UwMivDGHoRyMCvX9Ch1G2gIZZl5yKwzVNaBNpJiAyByWFuxrcBqQsSIFKBEbxeRjePE6QiBbkw==
   dependencies:
-    buffer "^4.9.1"
-    events "^1.1.1"
-    ieee754 "^1.1.13"
-    jmespath "^0.15.0"
-    querystring "^0.2.0"
-    sax "^1.2.1"
-    url "^0.10.3"
-    uuid "^3.3.2"
-    xml2js "^0.4.19"
+    buffer "4.9.2"
+    events "1.1.1"
+    ieee754 "1.1.13"
+    jmespath "0.15.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    uuid "3.3.2"
+    xml2js "0.4.19"
 
 aws-sign2@~0.7.0:
   version "0.7.0"
@@ -2310,7 +2310,7 @@ buffer-from@1.x, buffer-from@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
 
-buffer@^4.9.1:
+buffer@4.9.2:
   version "4.9.2"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.2.tgz#230ead344002988644841ab0244af8c44bbe3ef8"
   integrity sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==
@@ -3520,7 +3520,7 @@ eventemitter3@^3.1.0:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.2.tgz#2d3d48f9c346698fce83a85d7d664e98535df6e7"
   integrity sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==
 
-events@^1.1.1:
+events@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
   integrity sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=
@@ -4330,7 +4330,7 @@ iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@~0.4.13:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-ieee754@^1.1.13, ieee754@^1.1.4:
+ieee754@1.1.13, ieee754@^1.1.4:
   version "1.1.13"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
   integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
@@ -5284,7 +5284,7 @@ jest@26.6.3:
     import-local "^3.0.2"
     jest-cli "^26.6.3"
 
-jmespath@^0.15.0:
+jmespath@0.15.0:
   version "0.15.0"
   resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"
   integrity sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=
@@ -6887,7 +6887,7 @@ qs@~6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
-querystring@0.2.0, querystring@^0.2.0:
+querystring@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
   integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
@@ -7347,7 +7347,12 @@ sane@^4.0.3:
     minimist "^1.1.1"
     walker "~1.0.5"
 
-sax@>=0.6.0, sax@^1.2.1:
+sax@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
+  integrity sha1-e45lYZCyKOgaZq6nSEgNgozS03o=
+
+sax@>=0.6.0:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
@@ -8273,7 +8278,7 @@ urix@^0.1.0:
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
 
-url@^0.10.3:
+url@0.10.3:
   version "0.10.3"
   resolved "https://registry.yarnpkg.com/url/-/url-0.10.3.tgz#021e4d9c7705f21bbf37d03ceb58767402774c64"
   integrity sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=
@@ -8297,6 +8302,11 @@ util-promisify@^2.1.0:
   integrity sha1-PCI2R2xNMsX/PEcAKt18E7moKlM=
   dependencies:
     object.getownpropertydescriptors "^2.0.3"
+
+uuid@3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
+  integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
 uuid@^3.0.1, uuid@^3.3.2, uuid@^3.3.3:
   version "3.4.0"
@@ -8553,23 +8563,23 @@ xml-name-validator@^3.0.0:
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
 
-xml2js@^0.4.19:
-  version "0.4.23"
-  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.23.tgz#a0c69516752421eb2ac758ee4d4ccf58843eac66"
-  integrity sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==
+xml2js@0.4.19:
+  version "0.4.19"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7"
+  integrity sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==
   dependencies:
     sax ">=0.6.0"
-    xmlbuilder "~11.0.0"
+    xmlbuilder "~9.0.1"
 
 xml@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
   integrity sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=
 
-xmlbuilder@~11.0.0:
-  version "11.0.1"
-  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
-  integrity sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
+xmlbuilder@~9.0.1:
+  version "9.0.7"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
+  integrity sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=
 
 xmlchars@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
[CORE-1960](https://seismic.atlassian.net/browse/CORE-1960)
- Could use some help testing this. I didn't find any breaking changes in the API from the change log, but I'd feel better if we can verify it.