### PR TITLE
increase execSync maxBuffer

### DIFF
--- a/pkgs/cli-utils/CHANGELOG.md
+++ b/pkgs/cli-utils/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.13](https://github.com/percolate/blend/tree/master/pkgs/core/compare/@percolate/cli-utils@0.1.12...@percolate/cli-utils@0.1.13) (2021-07-27)
+
+**Note:** Version bump only for package @percolate/cli-utils
+
+
+
+
+
 ## [0.1.12](https://github.com/percolate/blend/tree/master/pkgs/core/compare/@percolate/cli-utils@0.1.11...@percolate/cli-utils@0.1.12) (2021-05-14)
 
 

--- a/pkgs/cli-utils/package.json
+++ b/pkgs/cli-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percolate/cli-utils",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Percolate CLI utils",
   "license": "CPAL-1.0",
   "repository": "https://github.com/percolate/blend/tree/master/pkgs/core",

--- a/pkgs/cli-utils/src/execSync.ts
+++ b/pkgs/cli-utils/src/execSync.ts
@@ -3,6 +3,8 @@ import * as childProcess from 'child_process'
 import { color } from './color'
 import { forceExit } from './forceExit'
 
+const maxBuffer = 1024 * 2560
+
 interface IExecSyncBaseOpts extends childProcess.ExecSyncOptions {
     onError?(err: Error): void
     verbose?: boolean
@@ -20,7 +22,7 @@ export function execSync(cmd: string, opts: IExecSyncBaseOpts | IExecSyncVerbose
     if (verbose) {
         console.log(color(cmd, 'grey'))
         try {
-            childProcess.execSync(cmd, { ...rest, stdio: 'inherit' })
+            childProcess.execSync(cmd, { ...rest, stdio: 'inherit', maxBuffer })
         } catch (e) {
             // do not pass error to forceExit to avoid duplicating error message
             onError(opts.onError ? e : undefined)
@@ -30,7 +32,7 @@ export function execSync(cmd: string, opts: IExecSyncBaseOpts | IExecSyncVerbose
 
     try {
         return childProcess
-            .execSync(cmd, { ...rest, stdio: 'pipe' })
+            .execSync(cmd, { ...rest, stdio: 'pipe', maxBuffer })
             .toString()
             .trim()
     } catch (e) {

--- a/pkgs/eslint-plugin/CHANGELOG.md
+++ b/pkgs/eslint-plugin/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.1.15](https://github.com/percolate/blend/tree/master/pkgs/eslint-plugin/compare/@percolate/eslint-plugin@1.1.14...@percolate/eslint-plugin@1.1.15) (2021-07-27)
+
+**Note:** Version bump only for package @percolate/eslint-plugin
+
+
+
+
+
 ## [1.1.14](https://github.com/percolate/blend/tree/master/pkgs/eslint-plugin/compare/@percolate/eslint-plugin@1.1.13...@percolate/eslint-plugin@1.1.14) (2021-05-14)
 
 **Note:** Version bump only for package @percolate/eslint-plugin

--- a/pkgs/eslint-plugin/package.json
+++ b/pkgs/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percolate/eslint-plugin",
-  "version": "1.1.14",
+  "version": "1.1.15",
   "description": "Percolate's ESlint rules and configs",
   "repository": "https://github.com/percolate/blend/tree/master/pkgs/eslint-plugin",
   "license": "CPAL-1.0",

--- a/pkgs/kona/CHANGELOG.md
+++ b/pkgs/kona/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.4.7](https://github.com/percolate/blend/tree/master/pkgs/kona/compare/@percolate/kona@3.4.6...@percolate/kona@3.4.7) (2021-07-27)
+
+**Note:** Version bump only for package @percolate/kona
+
+
+
+
+
 ## [3.4.6](https://github.com/percolate/blend/tree/master/pkgs/kona/compare/@percolate/kona@3.4.5...@percolate/kona@3.4.6) (2021-05-14)
 
 

--- a/pkgs/kona/package.json
+++ b/pkgs/kona/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percolate/kona",
-  "version": "3.4.6",
+  "version": "3.4.7",
   "description": "Percolate CLI",
   "license": "CPAL-1.0",
   "repository": "https://github.com/percolate/blend/tree/master/pkgs/kona",
@@ -29,7 +29,7 @@
     "@commitlint/format": "12.1.1",
     "@commitlint/lint": "12.1.1",
     "@commitlint/load": "12.1.1",
-    "@percolate/cli-utils": "0.1.12",
+    "@percolate/cli-utils": "0.1.13",
     "commitizen": "4.2.4",
     "fast-glob": "3.2.5",
     "find-up": "4.1.0",

--- a/pkgs/press/CHANGELOG.md
+++ b/pkgs/press/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.2.13](https://github.com/percolate/blend/tree/master/pkgs/press/compare/@percolate/press@1.2.12...@percolate/press@1.2.13) (2021-07-27)
+
+**Note:** Version bump only for package @percolate/press
+
+
+
+
+
 ## [1.2.12](https://github.com/percolate/blend/tree/master/pkgs/press/compare/@percolate/press@1.2.11...@percolate/press@1.2.12) (2021-05-14)
 
 **Note:** Version bump only for package @percolate/press

--- a/pkgs/press/package.json
+++ b/pkgs/press/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percolate/press",
-  "version": "1.2.12",
+  "version": "1.2.13",
   "description": "CI release tooling",
   "bin": {
     "press": "bin/press"
@@ -16,7 +16,7 @@
     "watch": "tsc --project . --watch"
   },
   "dependencies": {
-    "@percolate/cli-utils": "0.1.12",
+    "@percolate/cli-utils": "0.1.13",
     "@sentry/cli": "1.49.0",
     "aws-sdk": "2.885.0",
     "semver": "6.3.0",

--- a/pkgs/prettier-config/CHANGELOG.md
+++ b/pkgs/prettier-config/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.11](https://github.com/percolate/blend/tree/master/pkgs/prettier-config/compare/@percolate/prettier-config@0.1.10...@percolate/prettier-config@0.1.11) (2021-07-27)
+
+**Note:** Version bump only for package @percolate/prettier-config
+
+
+
+
+
 ## [0.1.10](https://github.com/percolate/blend/tree/master/pkgs/prettier-config/compare/@percolate/prettier-config@0.1.9...@percolate/prettier-config@0.1.10) (2021-05-14)
 
 **Note:** Version bump only for package @percolate/prettier-config

--- a/pkgs/prettier-config/package.json
+++ b/pkgs/prettier-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percolate/prettier-config",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Percolate prettier config",
   "repository": "https://github.com/percolate/blend/tree/master/pkgs/prettier-config",
   "license": "CPAL-1.0",

--- a/pkgs/publisher/CHANGELOG.md
+++ b/pkgs/publisher/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.12](https://github.com/percolate/blend/tree/master/pkgs/publisher/compare/@percolate/publisher@0.1.11...@percolate/publisher@0.1.12) (2021-07-27)
+
+**Note:** Version bump only for package @percolate/publisher
+
+
+
+
+
 ## [0.1.11](https://github.com/percolate/blend/tree/master/pkgs/publisher/compare/@percolate/publisher@0.1.10...@percolate/publisher@0.1.11) (2021-05-14)
 
 **Note:** Version bump only for package @percolate/publisher

--- a/pkgs/publisher/package.json
+++ b/pkgs/publisher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percolate/publisher",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Publish package if version is newer than NPM's",
   "repository": "https://github.com/percolate/blend/tree/master/pkgs/publisher",
   "bin": {
@@ -19,7 +19,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@percolate/cli-utils": "0.1.12",
+    "@percolate/cli-utils": "0.1.13",
     "docopt": "0.6.2",
     "semver": "6.3.0"
   },

--- a/pkgs/s3/CHANGELOG.md
+++ b/pkgs/s3/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.2.12](https://github.com/percolate/blend/tree/master/pkgs/s3/compare/@percolate/s3@1.2.11...@percolate/s3@1.2.12) (2021-07-27)
+
+**Note:** Version bump only for package @percolate/s3
+
+
+
+
+
 ## [1.2.11](https://github.com/percolate/blend/tree/master/pkgs/s3/compare/@percolate/s3@1.2.10...@percolate/s3@1.2.11) (2021-05-14)
 
 **Note:** Version bump only for package @percolate/s3

--- a/pkgs/s3/package.json
+++ b/pkgs/s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percolate/s3",
-  "version": "1.2.11",
+  "version": "1.2.12",
   "description": "CLI for various S3 commands",
   "license": "CPAL-1.0",
   "repository": "https://github.com/percolate/blend/tree/master/pkgs/s3",
@@ -19,7 +19,7 @@
     "watch": "tsc --build tsconfig.json --watch --preserveWatchOutput"
   },
   "dependencies": {
-    "@percolate/cli-utils": "0.1.12",
+    "@percolate/cli-utils": "0.1.13",
     "aws-sdk": "2.885.0",
     "console.table": "0.10.0",
     "docopt": "0.6.2",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/10822210/127221683-feb9b9f2-a8ff-4f41-83b5-e7a88a48af6c.png)

`bin/coverage` fails on exceptionally large diffs due to the default buffer limit of `childProcess.execSync`. Bumping to `1024 * 2560` seems to do the trick. Tested on a diff of almost [60k lines](https://github.com/percolate/rosetta/compare/AN-6052).