### PR TITLE
make prettier config more explicit

### DIFF
--- a/pkgs/cli-utils/CHANGELOG.md
+++ b/pkgs/cli-utils/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.14](https://github.com/percolate/blend/tree/master/pkgs/core/compare/@percolate/cli-utils@0.1.13...@percolate/cli-utils@0.1.14) (2021-08-17)
+
+**Note:** Version bump only for package @percolate/cli-utils
+
+
+
+
+
 ## [0.1.13](https://github.com/percolate/blend/tree/master/pkgs/core/compare/@percolate/cli-utils@0.1.12...@percolate/cli-utils@0.1.13) (2021-07-27)
 
 **Note:** Version bump only for package @percolate/cli-utils

--- a/pkgs/cli-utils/package.json
+++ b/pkgs/cli-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percolate/cli-utils",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Percolate CLI utils",
   "license": "CPAL-1.0",
   "repository": "https://github.com/percolate/blend/tree/master/pkgs/core",

--- a/pkgs/eslint-plugin/CHANGELOG.md
+++ b/pkgs/eslint-plugin/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.1.16](https://github.com/percolate/blend/tree/master/pkgs/eslint-plugin/compare/@percolate/eslint-plugin@1.1.15...@percolate/eslint-plugin@1.1.16) (2021-08-17)
+
+**Note:** Version bump only for package @percolate/eslint-plugin
+
+
+
+
+
 ## [1.1.15](https://github.com/percolate/blend/tree/master/pkgs/eslint-plugin/compare/@percolate/eslint-plugin@1.1.14...@percolate/eslint-plugin@1.1.15) (2021-07-27)
 
 **Note:** Version bump only for package @percolate/eslint-plugin

--- a/pkgs/eslint-plugin/package.json
+++ b/pkgs/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percolate/eslint-plugin",
-  "version": "1.1.15",
+  "version": "1.1.16",
   "description": "Percolate's ESlint rules and configs",
   "repository": "https://github.com/percolate/blend/tree/master/pkgs/eslint-plugin",
   "license": "CPAL-1.0",

--- a/pkgs/kona/CHANGELOG.md
+++ b/pkgs/kona/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.4.8](https://github.com/percolate/blend/tree/master/pkgs/kona/compare/@percolate/kona@3.4.7...@percolate/kona@3.4.8) (2021-08-17)
+
+**Note:** Version bump only for package @percolate/kona
+
+
+
+
+
 ## [3.4.7](https://github.com/percolate/blend/tree/master/pkgs/kona/compare/@percolate/kona@3.4.6...@percolate/kona@3.4.7) (2021-07-27)
 
 **Note:** Version bump only for package @percolate/kona

--- a/pkgs/kona/configs/prettier.json
+++ b/pkgs/kona/configs/prettier.json
@@ -2,8 +2,14 @@
     "$schema": "http://json.schemastore.org/prettierrc",
     "printWidth": 110,
     "tabWidth": 4,
+    "useTabs": false,
     "singleQuote": true,
+    "quoteProps": "as-needed",
+    "jsxSingleQuote": false,
     "trailingComma": "es5",
+    "bracketSpacing": true,
+    "jsxBracketSameLine": false,
+    "arrowParens": "avoid",
     "semi": false,
     "overrides": [
         {

--- a/pkgs/kona/package.json
+++ b/pkgs/kona/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percolate/kona",
-  "version": "3.4.7",
+  "version": "3.4.8",
   "description": "Percolate CLI",
   "license": "CPAL-1.0",
   "repository": "https://github.com/percolate/blend/tree/master/pkgs/kona",
@@ -29,7 +29,7 @@
     "@commitlint/format": "12.1.1",
     "@commitlint/lint": "12.1.1",
     "@commitlint/load": "12.1.1",
-    "@percolate/cli-utils": "0.1.13",
+    "@percolate/cli-utils": "0.1.14",
     "commitizen": "4.2.4",
     "fast-glob": "3.2.5",
     "find-up": "4.1.0",

--- a/pkgs/press/CHANGELOG.md
+++ b/pkgs/press/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.2.14](https://github.com/percolate/blend/tree/master/pkgs/press/compare/@percolate/press@1.2.13...@percolate/press@1.2.14) (2021-08-17)
+
+**Note:** Version bump only for package @percolate/press
+
+
+
+
+
 ## [1.2.13](https://github.com/percolate/blend/tree/master/pkgs/press/compare/@percolate/press@1.2.12...@percolate/press@1.2.13) (2021-07-27)
 
 **Note:** Version bump only for package @percolate/press

--- a/pkgs/press/package.json
+++ b/pkgs/press/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percolate/press",
-  "version": "1.2.13",
+  "version": "1.2.14",
   "description": "CI release tooling",
   "bin": {
     "press": "bin/press"
@@ -16,7 +16,7 @@
     "watch": "tsc --project . --watch"
   },
   "dependencies": {
-    "@percolate/cli-utils": "0.1.13",
+    "@percolate/cli-utils": "0.1.14",
     "@sentry/cli": "1.49.0",
     "aws-sdk": "2.885.0",
     "semver": "6.3.0",

--- a/pkgs/prettier-config/CHANGELOG.md
+++ b/pkgs/prettier-config/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.12](https://github.com/percolate/blend/tree/master/pkgs/prettier-config/compare/@percolate/prettier-config@0.1.11...@percolate/prettier-config@0.1.12) (2021-08-17)
+
+**Note:** Version bump only for package @percolate/prettier-config
+
+
+
+
+
 ## [0.1.11](https://github.com/percolate/blend/tree/master/pkgs/prettier-config/compare/@percolate/prettier-config@0.1.10...@percolate/prettier-config@0.1.11) (2021-07-27)
 
 **Note:** Version bump only for package @percolate/prettier-config

--- a/pkgs/prettier-config/package.json
+++ b/pkgs/prettier-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percolate/prettier-config",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Percolate prettier config",
   "repository": "https://github.com/percolate/blend/tree/master/pkgs/prettier-config",
   "license": "CPAL-1.0",

--- a/pkgs/prettier-config/prettier-config.json
+++ b/pkgs/prettier-config/prettier-config.json
@@ -2,8 +2,14 @@
     "$schema": "http://json.schemastore.org/prettierrc",
     "printWidth": 110,
     "tabWidth": 4,
+    "useTabs": false,
     "singleQuote": true,
+    "quoteProps": "as-needed",
+    "jsxSingleQuote": false,
     "trailingComma": "es5",
+    "bracketSpacing": true,
+    "jsxBracketSameLine": false,
+    "arrowParens": "avoid",
     "semi": false,
     "overrides": [
         {

--- a/pkgs/publisher/CHANGELOG.md
+++ b/pkgs/publisher/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.13](https://github.com/percolate/blend/tree/master/pkgs/publisher/compare/@percolate/publisher@0.1.12...@percolate/publisher@0.1.13) (2021-08-17)
+
+**Note:** Version bump only for package @percolate/publisher
+
+
+
+
+
 ## [0.1.12](https://github.com/percolate/blend/tree/master/pkgs/publisher/compare/@percolate/publisher@0.1.11...@percolate/publisher@0.1.12) (2021-07-27)
 
 **Note:** Version bump only for package @percolate/publisher

--- a/pkgs/publisher/package.json
+++ b/pkgs/publisher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percolate/publisher",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Publish package if version is newer than NPM's",
   "repository": "https://github.com/percolate/blend/tree/master/pkgs/publisher",
   "bin": {
@@ -19,7 +19,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@percolate/cli-utils": "0.1.13",
+    "@percolate/cli-utils": "0.1.14",
     "docopt": "0.6.2",
     "semver": "6.3.0"
   },

--- a/pkgs/s3/CHANGELOG.md
+++ b/pkgs/s3/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.2.13](https://github.com/percolate/blend/tree/master/pkgs/s3/compare/@percolate/s3@1.2.12...@percolate/s3@1.2.13) (2021-08-17)
+
+**Note:** Version bump only for package @percolate/s3
+
+
+
+
+
 ## [1.2.12](https://github.com/percolate/blend/tree/master/pkgs/s3/compare/@percolate/s3@1.2.11...@percolate/s3@1.2.12) (2021-07-27)
 
 **Note:** Version bump only for package @percolate/s3

--- a/pkgs/s3/package.json
+++ b/pkgs/s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percolate/s3",
-  "version": "1.2.12",
+  "version": "1.2.13",
   "description": "CLI for various S3 commands",
   "license": "CPAL-1.0",
   "repository": "https://github.com/percolate/blend/tree/master/pkgs/s3",
@@ -19,7 +19,7 @@
     "watch": "tsc --build tsconfig.json --watch --preserveWatchOutput"
   },
   "dependencies": {
-    "@percolate/cli-utils": "0.1.13",
+    "@percolate/cli-utils": "0.1.14",
     "aws-sdk": "2.885.0",
     "console.table": "0.10.0",
     "docopt": "0.6.2",


### PR DESCRIPTION
Adds explicit prettier config values. This helps ensure styles are preserved if any consumer of `kona lint` upgrades to prettier version >=2 where defaults have changed.